### PR TITLE
Fix URLs that are longer than the line-wrap limit

### DIFF
--- a/js/terminal-ext.js
+++ b/js/terminal-ext.js
@@ -45,14 +45,18 @@ extend = (term) => {
   }
 
   term.stylePrint = (text) => {
-    // Text Wrap
-    text = _wordWrap(text, Math.min(term.cols, 76));
-
     // Hyperlinks
     const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
     const urlMatches = text.matchAll(urlRegex);
+    let allowWrapping = true;
     for (match of urlMatches) {
+      allowWrapping = match[0].length < 76;
       text = text.replace(match[0], colorText(match[0], "hyperlink"));
+    }
+
+    // Text Wrap
+    if (allowWrapping) { 
+      text = _wordWrap(text, Math.min(term.cols, 76));
     }
 
     // Commands


### PR DESCRIPTION
I noticed that some of the portfolio company's URLs don't work:

![Screenshot from 2021-06-15 14-52-54](https://user-images.githubusercontent.com/765551/122128485-9a049e00-cde9-11eb-8423-38517645863b.png)

This is due to the line wrapping happening before URL extraction takes place. Simply reordering the checks wasn't enough because the *actual* logic to convert a URL into a clickable link is somewhere else, so I added some basic detection to just not wrap really long URLs, and now it works:

![Screenshot from 2021-06-15 14-53-07](https://user-images.githubusercontent.com/765551/122128621-c91b0f80-cde9-11eb-9caf-c7abf86597b6.png)
