### PR TITLE
Better anycloud URL

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -556,7 +556,7 @@ const commands = {
   },
 
   anycloud: function() {
-    term.command("alan");
+    term.stylePrint("https://docs.anycloudapp.com/documentation/tutorials/aws-node");
   },
 }
 


### PR DESCRIPTION
Anycloud is built on top of Alan, but that's basically hidden from the user, so I think if there's going to be an `anycloud` command here, it should point at a more relevant URL?