### PR TITLE
Change directory command improvements

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -204,7 +204,7 @@ const commands = {
         term.stylePrint(`You do not have permission to access this directory`);
         break;
       case "/bin":
-        term.command("bin")
+        term.cwd = "bin";
         break;
       case "bin":
         if (term.cwd == "/") {

--- a/config/commands.js
+++ b/config/commands.js
@@ -132,7 +132,7 @@ const commands = {
 
   // I am so, so sorry for this code.
   cd: function(args) {
-    const dir = args[0];
+    let dir = args[0] || "~";
     
     switch(dir) {
       case "~":
@@ -211,7 +211,6 @@ const commands = {
           term.stylePrint(`No such directory: ${dir}`);
         }
         break;
-      case "":
       case ".":
       case "./":
         break;

--- a/config/commands.js
+++ b/config/commands.js
@@ -133,23 +133,25 @@ const commands = {
   // I am so, so sorry for this code.
   cd: function(args) {
     let dir = args[0] || "~";
+    if (dir != "/") {
+      // strip trailing slash
+      dir = dir.replace(/\/$/, "");
+    }
     
     switch(dir) {
       case "~":
-      case "~/":
         term.cwd = "~";
         break;
       case "..":
-      case "../":
         if (term.cwd == "~") {
           term.command("cd /home");
         } else if (["home", "bin"].includes(term.cwd)) {
           term.command("cd /");
         }
         break;
-      case "../../":
-      case "../../../":
-      case "../../../../":
+      case "../..":
+      case "../../..":
+      case "../../../..":
       case "/":
         term.cwd = "/";
         break;
@@ -212,7 +214,6 @@ const commands = {
         }
         break;
       case ".":
-      case "./":
         break;
       default:
         term.stylePrint(`No such directory: ${dir}`);

--- a/js/terminal-ext.js
+++ b/js/terminal-ext.js
@@ -93,9 +93,9 @@ extend = (term) => {
   }
 
   term.command = (line) => {
-    const parts = line.split(" ");
+    const parts = line.split(/\s+/);
     const cmd = parts[0].toLowerCase();
-    const args = parts.slice(1, parts.length).map((el) => el.trim());
+    const args = parts.slice(1, parts.length)
     const fn = commands[cmd];
     if (typeof(fn) === "undefined") {
       term.stylePrint(`Command not found: ${cmd}. Try 'help' to get started.`);


### PR DESCRIPTION
I noticed some interesting behavior in `cd` and endeavored to make a few fixes. This PR

- Cleans up command parsing in general (I noticed `cd      asdf` passed a lot of blank arguments in, incorrectly)
- Defaults `cd` to be `cd ~`, which I believe is standard behavior everywhere
- Removes trailing slashes from the directory argument, which simplifies the big switch statement and also fixes a bug where `cd ../..` was not recognized
- Fixes a weird behavior where `cd /bin` attempted to run the command `bin` (unclear why it was this way before)

As part of putting all of this together, I created a small test suite, but I'm leaving that out of this PR because it adds Jest as a dependency and does need a few tweaks to other parts of the codebase to initialize globals properly. Lemme know if you want that, too.