### PR TITLE
add scp command

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -398,6 +398,10 @@ const commands = {
     term.command(`curl ${args.join(" ")}`);
   },
 
+  scp: function(args) {
+    term.stylePrint(`████████████ Request Blocked: The ███████████ Policy disallows reading the ██████ resource ${args[0]}.`);
+  },
+
   rm: function() {
     term.stylePrint("I can't let you do that, Dave");
   },


### PR DESCRIPTION
This adds support for the `scp` command similar to `ssh`, `sftp`, and `ftp`, but with a joke relating to the [SCP Foundation](http://scp-wiki.wikidot.com).