### PR TITLE
Clear current line after `upgrade`

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -667,6 +667,7 @@ const commands = {
     await term.delayPrint("Please report any bugs you find.\r\n", 1 * timeUnit);
 
     term.prompt();
+    term.clearCurrentLine();
     term.locked = false;
   },
 


### PR DESCRIPTION
Prevents the string "upgrade" from being appended to the next command typed.

Repro:

https://user-images.githubusercontent.com/709645/190023698-1d46dde6-9559-40e9-bbda-d996ac3076b3.mov

