### PR TITLE
Remove wordwrap for links so they don't break (on mobile and smaller

### DIFF
--- a/js/terminal-ext.js
+++ b/js/terminal-ext.js
@@ -90,15 +90,8 @@ extend = (term) => {
     // Hyperlinks
     const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
     const urlMatches = text.matchAll(urlRegex);
-    let allowWrapping = true;
     for (match of urlMatches) {
-      allowWrapping = match[0].length < 76;
       text = text.replace(match[0], colorText(match[0], "hyperlink"));
-    }
-
-    // Text Wrap
-    if (allowWrapping && wrap) {
-      text = _wordWrap(text, Math.min(term.cols, 76));
     }
 
     // Commands
@@ -192,31 +185,3 @@ extend = (term) => {
   }
 }
 
-// https://stackoverflow.com/questions/14484787/wrap-text-in-javascript
-// TODO: This doesn't work well at detecting newline
-function _wordWrap(str, maxWidth) {
-  var newLineStr = "\r\n"; done = false; res = '';
-  while (str.length > maxWidth) {
-    found = false;
-    // Inserts new line at first whitespace of the line
-    for (i = maxWidth - 1; i >= 0; i--) {
-      if (_testWhite(str.charAt(i))) {
-        res = res + [str.slice(0, i), newLineStr].join('');
-        str = str.slice(i + 1);
-        found = true;
-        break;
-      }
-    }
-    // Inserts new line at maxWidth position, the word is too long to wrap
-    if (!found) {
-      res += [str.slice(0, maxWidth), newLineStr].join('');
-      str = str.slice(maxWidth);
-    }
-  }
-  return res + str;
-}
-
-function _testWhite(x) {
-  var white = new RegExp(/^\s$/);
-  return white.test(x.charAt(0));
-};


### PR DESCRIPTION
screen sizes)

The current implementation of wordwrap is only used in the case of a link. At which point it checks against a maxWidth of 76 and breaks the link, and/or inserts a newline character if whitespace is found.

Introducing a newline character breaks the link and is seemingly unnecessary (may have to do with addonFit).

Introducing a newline on whitespace character is also seemingly unecessary as a URL should not have a whitespace character anywhere but possibly the end of the string.

Possible fix for #38 and #42 (the latter issue is less clear).

One possible oversight is that wordwrap may be useful for the case where a string with multiple URLs passed in separated by a whitespace character that should actually be a newline is missed. This doesn't appear to be a problem.