### PR TITLE
Add command for keyboard macro

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -470,6 +470,10 @@ const commands = {
     }
   },
 
+  keypad: async function(args) {
+    term.openURL("https://root.vc/keypad");
+  },
+
   locate: function() {
     term.stylePrint("Root Ventures");
     term.stylePrint("2670 Harrison St");


### PR DESCRIPTION
Currently the macro keyboard tries to execute the command `keypad` on the root.vc site because it is formatted as a command instead of a path.

Because it seems unlikely that the hardware itself will be updated on already sent devices, a command is added in this PR to make sure this still opens the URL correctly.

Alternatively / along with, a PR is created on the `macro_keyboard` repository to update the URL so that this change is not required in the future and links directly.

See: https://github.com/rootvc/macro_keyboard/pull/1