### PR TITLE
always unlock terminal

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -444,9 +444,9 @@ const commands = {
   },
 
   easterbunny: async function(args) {
-    term.locked = true;
-
     if (killed) {
+      term.locked = true;
+      
       if (term.VERSION != 3) {
         term.stylePrint("%easterbunny% only available in version 3.0. Use %upgrade% to upgrade.");
       } else if (args.length != 4) {


### PR DESCRIPTION
terminal is stuck in the `locked` state if you run the `easterbunny` command before killing the crypto miner process.