### PR TITLE
added ascii rick roll in terminal instead of opening gif in new window

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -92,7 +92,7 @@ const commands = {
   },
 
   test: function() {
-    term.openURL("https://i.imgur.com/Q2Unw.gif");
+    term.command("curl --max-time 6 -s ascii.live/rick")
   },
 
   email: function() {
@@ -242,7 +242,7 @@ const commands = {
       term.stylePrint(`No such file: ${filename}`);
     }
     if (filename == "id_rsa") {
-      term.openURL("https://i.imgur.com/Q2Unw.gif");
+      term.command("curl --max-time 6 -s ascii.live/rick")
     }
   },
 
@@ -251,7 +251,7 @@ const commands = {
     const filename = args[1];
 
     if (filename == "id_rsa") {
-      term.openURL("https://i.imgur.com/Q2Unw.gif");
+      term.command("curl --max-time 6 -s ascii.live/rick")
     }
 
     if (!q || !filename) {
@@ -357,7 +357,7 @@ const commands = {
       term.stylePrint("%open%: open a file - usage:\r\n");
       term.stylePrint("%open% test.htm");
     } else if (args[0].split(".")[0] == "test" && args[0].split(".")[1] == "htm") {
-      term.openURL("https://i.imgur.com/Q2Unw.gif");
+      term.command("curl --max-time 6 -s ascii.live/rick")
     } else if (args[0].split(".")[1] == "htm") {
       term.openURL(`./${args[0]}`, false);
     } else if (args.join(" ") == "the pod bay doors") {


### PR DESCRIPTION
Why open a new window to a gif/video when you could play an ascii version of rick roll in terminal!!!


https://github.com/rootvc/cli-website/assets/17733702/1b498805-559f-475f-b02b-5fdc8c2d194e

