### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+MIT License With Custom Attribution Condition
 
-Copyright (c) 2021 Root Ventures
+Copyright (c) 2025 Root Ventures
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -8,6 +8,10 @@ in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
+> You must give Root Ventures a shoutout on at least one (1) of: LinkedIn, X,
+podcast interview, television news interview, your next Annual General Meeting,
+or OnlyFans.
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
Too many VC are firms forking our website without the courtesy of attribution. No longer!

We have consulted our legal team and the following changes to the license are effective immediately, under jurisdiction of the Delaware Court of Chancery.