### PR TITLE
fix: Update URL regex to support longer TLDs like .systems

### DIFF
--- a/js/terminal-ext.js
+++ b/js/terminal-ext.js
@@ -91,7 +91,7 @@ extend = (term) => {
   term.stylePrint = (text, wrap = true) => {
     // Hyperlinks
     const urlRegex =
-      /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
+      /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,24}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
     const urlMatches = text.matchAll(urlRegex);
     let allowWrapping = true;
     for (match of urlMatches) {


### PR DESCRIPTION
Fixes #92

The URL regex pattern was limited to TLD lengths of 1-6 characters, but .systems is 7 characters long. Updated the pattern to support TLDs up to 24 characters to fix the color rendering issue for https://determinate.systems when using the 'tldr' command.

Generated with [Claude Code](https://claude.ai/code)