### PR TITLE
fix: sort portfolio companies alphabetically on geocities page

### DIFF
--- a/js/geo.js
+++ b/js/geo.js
@@ -5,7 +5,10 @@ function buildGeoPage() {
   whois.innerHTML = whoisRoot.split(" Try")[0];
 
   const portfolioTable = document.getElementById("portfolio");
-  for (p in portfolio) {
+  const sortedPortfolioKeys = Object.keys(portfolio).sort((a, b) => 
+    portfolio[a].name.localeCompare(portfolio[b].name)
+  );
+  for (const p of sortedPortfolioKeys) {
     const row = portfolioTable.insertRow(-1);
     const logoCell = row.insertCell();
     const descriptionCell = row.insertCell();


### PR DESCRIPTION
Modified buildGeoPage() function to sort portfolio companies by their display name using localeCompare() for proper alphabetical ordering.

Fixes #93

Generated with [Claude Code](https://claude.ai/code)