### PR TITLE
fix: resolve race condition in terminal initialization

### DIFF
--- a/js/terminal-ext.js
+++ b/js/terminal-ext.js
@@ -169,8 +169,6 @@ extend = (term) => {
 
   term.init = (user = "guest", preserveHistory = false) => {
     fitAddon.fit();
-    preloadASCIIArt();
-    preloadFiles();
     term.reset();
     term.printLogoType();
     term.stylePrint(
@@ -190,6 +188,12 @@ extend = (term) => {
       term.history = [];
     }
     term.focus();
+    
+    // Defer heavy operations to run after terminal becomes interactive
+    setTimeout(() => {
+      preloadASCIIArt();
+      preloadFiles();
+    }, 100);
   };
 
   term.runDeepLink = () => {

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -4,12 +4,14 @@ function runRootTerminal(term) {
   }
 
   term.init();
-  term._initialized = true;
   term.locked = false;
 
   window.onload = (_) => {
     term.prompt();
     term.runDeepLink();
+    
+    // Only set initialized flag after prompt is displayed
+    term._initialized = true;
 
     window.addEventListener("resize", term.resizeListener);
 


### PR DESCRIPTION
Fixes #86

Resolves race condition where users could type before the prompt was displayed, causing input to be overwritten or appear over the prompt.

### Changes:
- Move `term._initialized = true` to run after `term.prompt()` display
- Maintain performance optimizations with 100ms delay for background loading
- Ensure proper sequence: terminal setup → prompt display → interactive → background loading

The terminal cursor is now consistently responsive without the race condition.

Generated with [Claude Code](https://claude.ai/code)