### PR TITLE
Add cowsay command and whois new_associate "easter" egg

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -159,6 +159,24 @@ const commands = {
     term.stylePrint(`(Robot voice): ${message}`);
   },
 
+  cowsay: function (args) {
+    const message = args.join(" ") || "moo";
+    const msgLen = message.length;
+    const top = " " + "_".repeat(msgLen + 2);
+    const bottom = " " + "-".repeat(msgLen + 2);
+    const cow = [
+      `< ${message} >`,
+      bottom,
+      "        \\   ^__^",
+      "         \\  (oo)\\_______",
+      "            (__)\\       )\\/\\",
+      "                ||----w |",
+      "                ||     ||",
+    ];
+    term.writeln(top);
+    cow.forEach((line) => term.writeln(line));
+  },
+
   pwd: function () {
     term.stylePrint("/" + term.cwd.replaceAll("~", `home/${term.user}`));
   },


### PR DESCRIPTION
Two commands:

1. `cowsay` — Defaults to "moo" if no input.

2. `whois new_associate` — an "Easter egg" code (doesn't modify the team list or help text). I'm applying for the associate role and figured a PR was fun. Portrait for ascii included.

Happy to split into two separate PRs if (new_associate == no).