### PR TITLE
Add RiderAI to portfolio (pitch)

### DIFF
--- a/config/portfolio.js
+++ b/config/portfolio.js
@@ -440,5 +440,13 @@ const portfolio = {
     url: "https://vbr.sh/",
     description:
       "Vibe Robotics, founded by Kai Backman and Luke Church, builds novel programming interfaces for robotics.",
+  },
+
+  riderai: {
+    name: "RiderAI",
+    url: "https://therider.ai",
+    description:
+      "RiderAI is the AI intelligence layer for motorcycles and scooters, intervening in real time on brake and throttle to make the world's most popular — and most dangerous — vehicles dramatically safer and smarter.",
+    demo: "https://therider.ai",
   }
 };


### PR DESCRIPTION
Hi Root team, this PR adds RiderAI to `config/portfolio.js` (and, via the auto-registration loop at the bottom of `commands.js`, a `riderai` command to the terminal). 

It's also, transparently, a pitch for a meeting with Kane or Chrissy. I know PR-as-outreach is unusual, but after reading Chrissy's LinkedIn message to hack the website for a meeting this felt like the best channel for a cold outreach.

 ## About RiderAI

RiderAI is making motorcycles and scooters dramatically safer — and smarter — for riders worldwide. We're building the AI intelligence layer they're sorely missing: real-time interventions on brake and throttle, bringing the advanced capabilities of automotive ADAS to the unique dynamics of two-wheelers while opening the door to capabilities far beyond safety. Our AI is trained specifically on real-world riding data from two-wheelers, enabling split-second decisions that only fire in truly critical, high-risk scenarios, protecting riders without compromising their control or experience.

Deck: https://docsend.com/view/2qicknmqc5b8wf69

## Contact
  - Shaurya Agarwal, Founder
  - shaurya@therider.ai
  - https://www.linkedin.com/in/agarwalshaurya/

  ---
Happy to close this PR immediately if it's noise, no hard feelings. If this is in the ballpark of your thesis, I'd love 20 minutes with Kane or Chrissy.