### PR TITLE
Stop Vercel from building the main line

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ In local repeated Chromium benchmarks against the previous `HEAD`, median startu
  - homepage first command rendered: `2076.5ms` -> `223.5ms`
  - `#whois-lee` deep link rendered: `1159.9ms` -> `151.9ms`
 
+## Hosting
+root.vc is served by **Netlify** — `server: Netlify` on the live response, the
+apex `A` record points at Netlify's load balancer, and `www` 301s to the apex.
+
+The repo is also connected to a **Vercel** project. That project is used by the
+`ai-incarnations` branch (the parked AI-reinvention experiment, #110), which
+carries its own `vercel.json` and builds there successfully. `main` has no
+Vercel deployment, so Vercel had nothing to build on this line: every attempt
+failed and posted a red check on PRs that had nothing to do with Vercel.
+
+`vercel.json` here sets [`git.deploymentEnabled: false`][1], which turns off
+automatic Vercel deployments for branches carrying this file.
+
+Do not "fix" this by making it match the `ai-incarnations` copy — that branch
+deliberately omits the key so it keeps deploying. If it is ever merged down,
+expect a conflict on `vercel.json` and resolve it toward whichever host is
+actually serving the domain at that point.
+
+[1]: https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled
+
 Live at: [https://root.vc](https://root.vc).
 
 Special thanks to [Jerry Neumann](https://www.linkedin.com/in/jerryneumann/) at [Neu Venture Capital](https://neuvc.com/) for the inspiration for this website concept.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Two files, no behavior change to the site. Split out of #121 so it can land on its own — it's unrelated to the static-mirror work and fixes the red check on `main` and on every open PR.

## The problem

The Vercel project is connected at the **repo** level, so it attempted a build on every branch. Only `ai-incarnations` carries a `vercel.json`; on this line Vercel had nothing to build, so every attempt failed and posted a red `Vercel` check — on `main` itself and on PRs that have nothing to do with Vercel.

It wasn't a stale integration. It was a real failure of a deployment that was never supposed to happen here.

## The fix

`git.deploymentEnabled: false` — [documented](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled) as turning off automatic deployments for branches carrying the file.

**`ai-incarnations` is unaffected.** It carries its own `vercel.json` *without* that key and its builds are green today. The README says so, and says not to reconcile the two files, because the difference is the point.

## Verified

- Same change on #121 already made the failing `Vercel` check disappear there — `test` passes, no red check
- `ai-incarnations` still reports `Vercel: success`
- `main` has no branch protection and no required status checks, so nothing depended on the `Vercel` context existing. I checked before making a check vanish rather than turn green
- root.vc is Netlify: `server: Netlify` and `x-nf-request-id` on the live response, apex `A` at `75.2.60.5`, `www` 301s to apex

## Note for whoever merges

`vercel.json` here is byte-identical to the copy on #121, so the two merge cleanly in either order. The README section lives only here to avoid a conflict.

The remaining `Vercel Agent Review` check reports `skipping — insufficient Credit`. That's a billing state on the Vercel account, unrelated, and it reports neutral rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
