### PR TITLE
Fix apply selection for every listed job

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -788,102 +788,110 @@ const commands = {
   // collectInput() resolves to: a string on submit, "" if skipped (optional
   // fields), or null on Ctrl+C. Null means the user cancelled.
   apply: function (args) {
-    if (args == 1 || (args.length > 0 && args[0] == 1)) {
-      term.locked = true;
+    const jobId = Array.isArray(args) ? args[0] : args;
 
-      (async () => {
-        // Shared cancellation handler — restores the terminal to a usable state.
-        const cancel = () => {
-          term.stylePrint("\r\nApplication cancelled.");
-          term.prompt();
-          term.clearCurrentLine(true);
-          term.locked = false;
-        };
-
-        term.stylePrint(
-          "Great! Let's get your application started. (Press Ctrl+C to cancel at any time)\r\n"
-        );
-
-        const name = await term.collectInput("What's your name?");
-        if (!name) { cancel(); return; }
-
-        const email = await term.collectInput("Email address");
-        if (!email) { cancel(); return; }
-
-        const linkedin = await term.collectInput("LinkedIn profile URL", true);
-        if (linkedin === null) { cancel(); return; }
-
-        const github = await term.collectInput("GitHub username", true);
-        if (github === null) { cancel(); return; }
-
-        const notes = await term.collectInput(
-          "Why Root? What makes you a great fit?",
-          true
-        );
-        if (notes === null) { cancel(); return; }
-
-        term.stylePrint("\r\nSubmitting application...");
-
-        try {
-          const response = await fetch("/.netlify/functions/submit-application", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              name,
-              email,
-              linkedin: linkedin || undefined,
-              github: github || undefined,
-              notes: notes || undefined,
-              position: "Venture Capital Associate",
-            }),
-          });
-
-          const result = await response.json();
-
-          if (response.ok) {
-            term.stylePrint(
-              `\r\n${colorText("✓", "prompt")} Application submitted successfully!`
-            );
-            term.stylePrint(
-              "\r\nThanks for applying! We'll review your application and get back to you soon."
-            );
-            term.stylePrint(
-              `\r\nIn the meantime, check out our portfolio with ${colorText(
-                "tldr",
-                "command"
-              )} or learn more about the team with ${colorText(
-                "whois",
-                "command"
-              )}.`
-            );
-          } else {
-            throw new Error(result.error || "Submission failed");
-          }
-        } catch (error) {
-          term.stylePrint(
-            `\r\n${colorText("✗", "user")} Error submitting application: ${error.message}`
-          );
-          term.stylePrint(
-            `\r\nPlease try again or email us directly at ${firm.email}`
-          );
-        }
-
-        term.prompt();
-        term.clearCurrentLine(true);
-        term.locked = false;
-      })();
-
-      // Return 1 synchronously so terminal.js skips its automatic prompt render.
-      return 1;
-    } else if (!args || args == "" || args.length === 0) {
+    if (!jobId) {
       term.stylePrint(
         "Please provide a job id. Use %jobs% to list all current jobs."
       );
-    } else {
-      term.stylePrint(
-        `Job id ${args[0]} not found. Use %jobs% to list all current jobs.`
-      );
+      return;
     }
+
+    if (!Object.prototype.hasOwnProperty.call(jobs, jobId)) {
+      term.stylePrint(
+        `Job id ${jobId} not found. Use %jobs% to list all current jobs.`
+      );
+      return;
+    }
+
+    const job = jobs[jobId];
+
+    term.locked = true;
+
+    (async () => {
+      // Shared cancellation handler — restores the terminal to a usable state.
+      const cancel = () => {
+        term.stylePrint("\r\nApplication cancelled.");
+        term.prompt();
+        term.clearCurrentLine(true);
+        term.locked = false;
+      };
+
+      term.stylePrint(
+        "Great! Let's get your application started. (Press Ctrl+C to cancel at any time)\r\n"
+      );
+
+      const name = await term.collectInput("What's your name?");
+      if (!name) { cancel(); return; }
+
+      const email = await term.collectInput("Email address");
+      if (!email) { cancel(); return; }
+
+      const linkedin = await term.collectInput("LinkedIn profile URL", true);
+      if (linkedin === null) { cancel(); return; }
+
+      const github = await term.collectInput("GitHub username", true);
+      if (github === null) { cancel(); return; }
+
+      const notes = await term.collectInput(
+        "Why Root? What makes you a great fit?",
+        true
+      );
+      if (notes === null) { cancel(); return; }
+
+      term.stylePrint("\r\nSubmitting application...");
+
+      try {
+        const response = await fetch("/.netlify/functions/submit-application", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name,
+            email,
+            linkedin: linkedin || undefined,
+            github: github || undefined,
+            notes: notes || undefined,
+            position: job[0],
+          }),
+        });
+
+        const result = await response.json();
+
+        if (response.ok) {
+          term.stylePrint(
+            `\r\n${colorText("✓", "prompt")} Application submitted successfully!`
+          );
+          term.stylePrint(
+            "\r\nThanks for applying! We'll review your application and get back to you soon."
+          );
+          term.stylePrint(
+            `\r\nIn the meantime, check out our portfolio with ${colorText(
+              "tldr",
+              "command"
+            )} or learn more about the team with ${colorText(
+              "whois",
+              "command"
+            )}.`
+          );
+        } else {
+          throw new Error(result.error || "Submission failed");
+        }
+      } catch (error) {
+        term.stylePrint(
+          `\r\n${colorText("✗", "user")} Error submitting application: ${error.message}`
+        );
+        term.stylePrint(
+          `\r\nPlease try again or email us directly at ${firm.email}`
+        );
+      }
+
+      term.prompt();
+      term.clearCurrentLine(true);
+      term.locked = false;
+    })();
+
+    // Return 1 synchronously so terminal.js skips its automatic prompt render.
+    return 1;
   },
 };
 

--- a/tests/commands.test.js
+++ b/tests/commands.test.js
@@ -1,0 +1,299 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createBrowserEnv } from "./helpers/browser-env";
+
+const jobsFixture = {
+  1: ["Venture Capital Associate", "Job 1 body"],
+  2: ["Platform Engineer", "Job 2 body"],
+};
+
+const baseGlobals = {
+  _DIRS: { "~": [] },
+  colorText: (text) => text,
+  firm: {
+    blurb: "Root Ventures",
+    email: "jobs@root.vc",
+  },
+  help: {},
+  jobs: jobsFixture,
+  portfolio: {},
+  team: {
+    root: { name: "Root", title: "Team", linkedin: "", description: "" },
+  },
+};
+
+let env;
+
+function loadCommands(globals = {}) {
+  env = createBrowserEnv({
+    globals: {
+      ...baseGlobals,
+      ...globals,
+    },
+  });
+  env.loadScripts(["config/commands.js"]);
+  return env.exportValues(["commands"]);
+}
+
+function createTerm(overrides = {}) {
+  return {
+    clearCurrentLine: vi.fn(),
+    collectInput: vi.fn(),
+    command: vi.fn(),
+    cols: 120,
+    cwd: "~",
+    displayURL: vi.fn(),
+    locked: false,
+    prompt: vi.fn(),
+    stylePrint: vi.fn(),
+    user: "guest",
+    writeln: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  if (env) {
+    env.cleanup();
+    env = null;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("commands.apply", () => {
+  it("preserves apply 1 behavior and submits the first job title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    });
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm({
+      collectInput: vi
+        .fn()
+        .mockResolvedValueOnce("Test User")
+        .mockResolvedValueOnce("test@example.com")
+        .mockResolvedValueOnce("https://linkedin.com/in/test")
+        .mockResolvedValueOnce("tester")
+        .mockResolvedValueOnce("Because Root."),
+    });
+
+    env.window.term = term;
+
+    expect(commands.apply(["1"])).toBe(1);
+    expect(term.locked).toBe(true);
+
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith("/.netlify/functions/submit-application", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Test User",
+        email: "test@example.com",
+        linkedin: "https://linkedin.com/in/test",
+        github: "tester",
+        notes: "Because Root.",
+        position: jobsFixture[1][0],
+      }),
+    });
+    expect(term.prompt).toHaveBeenCalledTimes(1);
+    expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+    expect(term.locked).toBe(false);
+  });
+
+  it("resolves job 2 from the registry and submits that job title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    });
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm({
+      collectInput: vi
+        .fn()
+        .mockResolvedValueOnce("Second User")
+        .mockResolvedValueOnce("two@example.com")
+        .mockResolvedValueOnce("")
+        .mockResolvedValueOnce("")
+        .mockResolvedValueOnce("Built from registry."),
+    });
+
+    env.window.term = term;
+
+    expect(commands.apply(["2"])).toBe(1);
+    expect(term.locked).toBe(true);
+
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith("/.netlify/functions/submit-application", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Second User",
+        email: "two@example.com",
+        linkedin: undefined,
+        github: undefined,
+        notes: "Built from registry.",
+        position: jobsFixture[2][0],
+      }),
+    });
+    expect(term.prompt).toHaveBeenCalledTimes(1);
+    expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+    expect(term.locked).toBe(false);
+  });
+
+  it("keeps the existing missing job id error", () => {
+    const fetchMock = vi.fn();
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm();
+
+    env.window.term = term;
+
+    expect(commands.apply([])).toBeUndefined();
+
+    expect(term.stylePrint).toHaveBeenCalledWith(
+      "Please provide a job id. Use %jobs% to list all current jobs."
+    );
+    expect(term.collectInput).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(term.locked).toBe(false);
+  });
+
+  it("keeps the existing unknown job id error", () => {
+    const fetchMock = vi.fn();
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm();
+
+    env.window.term = term;
+
+    expect(commands.apply(["99"])).toBeUndefined();
+
+    expect(term.stylePrint).toHaveBeenCalledWith(
+      "Job id 99 not found. Use %jobs% to list all current jobs."
+    );
+    expect(term.collectInput).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(term.locked).toBe(false);
+  });
+
+  it("rejects inherited object keys without collecting input or submitting", () => {
+    const fetchMock = vi.fn();
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm();
+
+    env.window.term = term;
+
+    expect(commands.apply(["__proto__"])).toBeUndefined();
+    expect(commands.apply(["constructor"])).toBeUndefined();
+    expect(commands.apply(["toString"])).toBeUndefined();
+
+    expect(term.stylePrint).toHaveBeenNthCalledWith(
+      1,
+      "Job id __proto__ not found. Use %jobs% to list all current jobs."
+    );
+    expect(term.stylePrint).toHaveBeenNthCalledWith(
+      2,
+      "Job id constructor not found. Use %jobs% to list all current jobs."
+    );
+    expect(term.stylePrint).toHaveBeenNthCalledWith(
+      3,
+      "Job id toString not found. Use %jobs% to list all current jobs."
+    );
+    expect(term.collectInput).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(term.locked).toBe(false);
+  });
+
+  it("cancels cleanly without submitting when input collection is interrupted", async () => {
+    const fetchMock = vi.fn();
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm({
+      collectInput: vi.fn().mockResolvedValueOnce(null),
+    });
+
+    env.window.term = term;
+
+    expect(commands.apply(["2"])).toBe(1);
+    expect(term.locked).toBe(true);
+
+    await settle();
+
+    expect(term.stylePrint).toHaveBeenCalledWith("\r\nApplication cancelled.");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(term.prompt).toHaveBeenCalledTimes(1);
+    expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+    expect(term.locked).toBe(false);
+  });
+
+  it("reports server failures and restores terminal state", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({ error: "Server exploded" }),
+    });
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm({
+      collectInput: vi
+        .fn()
+        .mockResolvedValueOnce("Failure User")
+        .mockResolvedValueOnce("fail@example.com")
+        .mockResolvedValueOnce("")
+        .mockResolvedValueOnce("")
+        .mockResolvedValueOnce("Please fail."),
+    });
+
+    env.window.term = term;
+
+    expect(commands.apply(["1"])).toBe(1);
+
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(term.stylePrint).toHaveBeenCalledWith(
+      "\r\n✗ Error submitting application: Server exploded"
+    );
+    expect(term.stylePrint).toHaveBeenCalledWith(
+      "\r\nPlease try again or email us directly at jobs@root.vc"
+    );
+    expect(term.prompt).toHaveBeenCalledTimes(1);
+    expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+    expect(term.locked).toBe(false);
+  });
+
+  it("prints the existing success flow and restores terminal state", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    });
+    const { commands } = loadCommands({ fetch: fetchMock });
+    const term = createTerm({
+      collectInput: vi
+        .fn()
+        .mockResolvedValueOnce("Success User")
+        .mockResolvedValueOnce("success@example.com")
+        .mockResolvedValueOnce("")
+        .mockResolvedValueOnce("")
+        .mockResolvedValueOnce("Ship it."),
+    });
+
+    env.window.term = term;
+
+    expect(commands.apply(["1"])).toBe(1);
+
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(term.stylePrint).toHaveBeenCalledWith(
+      "\r\n✓ Application submitted successfully!"
+    );
+    expect(term.stylePrint).toHaveBeenCalledWith(
+      "\r\nThanks for applying! We'll review your application and get back to you soon."
+    );
+    expect(term.prompt).toHaveBeenCalledTimes(1);
+    expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+    expect(term.locked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve `apply <job_id>` from the jobs registry instead of accepting only job 1
- submit the selected job title as the application position
- preserve existing behavior for job 1 and existing missing or unknown job errors
- add focused mocked coverage for jobs 1 and 2, cancellation, success, server failure, and invalid input
- leave `config/jobs.js` unchanged

## Validation
- `npm test` — passed (241 tests)
- `npm run build` — passed

## Scope
The reviewed run-baseline diff is limited to:
- `config/commands.js`
- `tests/commands.test.js`

All `collectInput` and `fetch` interactions in the focused tests are mocked, so the live application endpoint is not called.

## Delivery controls
Deterministic policy checks passed and the work packet has no open workflow approvals. This draft pull request is the human-confirmed completion action for ASD workflow task `task_09678545e08b400181f5235d55aae0de` on lifecycle-owned branch `asd/run/workflow_run_d3210818729-2dd84f2743d6340b1f690c0f3edbe51d`. No separate contact is part of this delivery.

<!-- asd-delivery-assignment:ZGVsaXZlcnlfYXNzaWdubWVudF9mZmI3MzI4NDY2MTNjNjNkNzk1OTc4YWJhMzlhYzZjNA -->