### PR TITLE
Fix apply job selection for all listed jobs

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -788,7 +788,11 @@ const commands = {
   // collectInput() resolves to: a string on submit, "" if skipped (optional
   // fields), or null on Ctrl+C. Null means the user cancelled.
   apply: function (args) {
-    if (args == 1 || (args.length > 0 && args[0] == 1)) {
+    const jobId = args && (Array.isArray(args) ? args[0] : args);
+    const hasJob = Object.prototype.hasOwnProperty.call(jobs, jobId);
+    const job = hasJob ? jobs[jobId] : null;
+
+    if (hasJob) {
       term.locked = true;
 
       (async () => {
@@ -834,7 +838,7 @@ const commands = {
               linkedin: linkedin || undefined,
               github: github || undefined,
               notes: notes || undefined,
-              position: "Venture Capital Associate",
+              position: job[0],
             }),
           });
 

--- a/tests/commands.test.js
+++ b/tests/commands.test.js
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+const commandSource = readFileSync("config/commands.js", "utf8");
+const jobsContext = vm.createContext({ module: { exports: {} } });
+vm.runInContext(`${readFileSync("config/jobs.js", "utf8")}\nthis.productionJobs = jobs;`, jobsContext);
+const productionJobs = jobsContext.productionJobs;
+const testJobs = { ...productionJobs, 2: ["Platform Engineer"] };
+
+function loadApply({ inputs = [], jobs = testJobs, response } = {}) {
+  const term = {
+    locked: false,
+    stylePrint: vi.fn(),
+    prompt: vi.fn(),
+    clearCurrentLine: vi.fn(),
+    collectInput: vi.fn(),
+  };
+  inputs.forEach((input) => term.collectInput.mockResolvedValueOnce(input));
+  const fetch = vi.fn().mockResolvedValue(
+    response || { ok: true, json: vi.fn().mockResolvedValue({}) }
+  );
+  const context = vm.createContext({
+    term,
+    jobs,
+    firm: { blurb: "", email: "hello@example.com" },
+    team: {},
+    help: {},
+    portfolio: {},
+    colorText: (text) => text,
+    fetch,
+  });
+  vm.runInContext(commandSource, context);
+  return { apply: vm.runInContext("commands.apply", context), term, fetch };
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for apply to settle");
+}
+
+describe("apply", () => {
+  it("submits each selected registry title for jobs 1 and 2 without a live request", async () => {
+    for (const [id, jobs] of [["1", productionJobs], ["2", testJobs]]) {
+      const { apply, fetch } = loadApply({ jobs, inputs: ["Ada", "ada@example.com", "", "", ""] });
+      expect(apply([id])).toBe(1);
+      await waitFor(() => fetch.mock.calls.length === 1);
+      expect(fetch).toHaveBeenCalledWith(
+        "/.netlify/functions/submit-application",
+        expect.objectContaining({ body: expect.stringContaining(`"position":"${jobs[id][0]}"`) })
+      );
+    }
+  });
+
+  it("preserves missing and unknown job errors without collecting or fetching", () => {
+    const missing = loadApply();
+    missing.apply([]);
+    expect(missing.term.stylePrint).toHaveBeenCalledWith("Please provide a job id. Use %jobs% to list all current jobs.");
+    expect(missing.term.collectInput).not.toHaveBeenCalled();
+    expect(missing.fetch).not.toHaveBeenCalled();
+
+    const unknown = loadApply();
+    unknown.apply(["99"]);
+    expect(unknown.term.stylePrint).toHaveBeenCalledWith("Job id 99 not found. Use %jobs% to list all current jobs.");
+    expect(unknown.term.collectInput).not.toHaveBeenCalled();
+    expect(unknown.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects prototype-inherited ids without collecting or fetching", () => {
+    const unknown = loadApply();
+    unknown.apply(["toString"]);
+    expect(unknown.term.stylePrint).toHaveBeenCalledWith("Job id toString not found. Use %jobs% to list all current jobs.");
+    expect(unknown.term.collectInput).not.toHaveBeenCalled();
+    expect(unknown.fetch).not.toHaveBeenCalled();
+  });
+
+  it("cancels without fetching and restores the terminal", async () => {
+    const { apply, term, fetch } = loadApply({ inputs: [null] });
+    expect(apply(["1"])).toBe(1);
+    await waitFor(() => term.prompt.mock.calls.length === 1);
+    expect(term.stylePrint).toHaveBeenCalledWith("\r\nApplication cancelled.");
+    expect(term.prompt).toHaveBeenCalled();
+    expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+    expect(term.locked).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("restores the terminal after successful and failed server submissions", async () => {
+    for (const [response, output] of [
+      [
+        { ok: true, json: vi.fn().mockResolvedValue({}) },
+        "\r\n✓ Application submitted successfully!",
+      ],
+      [
+        { ok: false, json: vi.fn().mockResolvedValue({ error: "Server failed" }) },
+        "\r\n✗ Error submitting application: Server failed",
+      ],
+    ]) {
+      const { apply, term, fetch } = loadApply({ inputs: ["Ada", "ada@example.com", "", "", ""], response });
+      expect(apply(["1"])).toBe(1);
+      await waitFor(() => fetch.mock.calls.length === 1);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(term.stylePrint).toHaveBeenCalledWith(output);
+      expect(term.prompt).toHaveBeenCalled();
+      expect(term.clearCurrentLine).toHaveBeenCalledWith(true);
+      expect(term.locked).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve `apply <job_id>` from the jobs registry instead of accepting only job 1.
- Submit the selected job title as the application position while preserving existing missing and invalid job errors.
- Add focused mocked command coverage for jobs 1 and 2, missing and unknown IDs, cancellation, success, and server-failure flows.

## Validation
- `npm test` — passed (238 tests)
- `npm run build` — passed

## Scope and review
- Changed only `config/commands.js` and `tests/commands.test.js`; `config/jobs.js` remains unchanged.
- Independent review confirmed the complete run-baseline diff and validation evidence.
- Required policy checks were allowed with no open approvals. This draft PR creation remains subject to governed human confirmation.

Workflow run: `workflow_run_71544849338-ab2773051f46ff7adaef7fb7d1703067`.
Work packet: `task_6de8d7c79eb446bc860a40912b9cd1d3`.

<!-- asd-delivery-assignment:ZGVsaXZlcnlfYXNzaWdubWVudF9iYTE1NTkwM2QyODE3MmIyNjdkMGJiOWQxNTY4ZTMxZA -->