### PR TITLE
Disable the swag command for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Who needs a website when you have a terminal.
   - instagram: instagram account
   - git: this repo
   - github: all repos
-  - swag: rootvc store
   - locate: physical address
   - www: plain-text version of this site
   - test: do not use

--- a/config/commands.js
+++ b/config/commands.js
@@ -171,10 +171,6 @@ const commands = {
     term.displayURL("https://github.com/rootvc");
   },
 
-  swag: function () {
-    term.openURL("https://rootvc.creator-spring.com");
-  },
-
   twitter: function () {
     term.displayURL("https://twitter.com/rootvc");
     term.displayURL("https://twitter.com/machinepix");

--- a/config/help.js
+++ b/config/help.js
@@ -13,7 +13,6 @@ const help = {
   "%locate%": "physical address",
   "%www%": "plain-text version of this site",
   "%jobs%": "check out our job openings",
-  "%swag%": "rootvc store",
   "%test%": "do not use",
   "%upgrade%": "upgrade to the latest version of Root Ventures",
   "%other%": "try your fav commands (e.g. %ls%, %groups%, %su%)",


### PR DESCRIPTION
Takes `swag` back out of the terminal.

Removed from `config/commands.js`, `config/help.js` and the README together — the help/commands sync test from #135 requires all three to move as a unit, which is exactly what it's for.

This reverts only the command from #132. That PR's README rewrite for the mirror removal stays.

To restore it later, three lines:

```
config/commands.js  swag: function () { term.openURL("https://rootvc.creator-spring.com"); }
config/help.js      "%swag%": "rootvc store",
README.md           - swag: rootvc store
```

## Test plan

- [x] `npm test` — all passing, including the help/commands sync check

🤖 Generated with [Claude Code](https://claude.com/claude-code)