### PR TITLE
Require confirmation for eval deep links

### DIFF
--- a/js/terminal-ext.js
+++ b/js/terminal-ext.js
@@ -415,7 +415,13 @@ const extend = (term) => {
   // directly rather than executeCommandLine for exactly this reason.
   term.runDeepLink = ({ replay = false } = {}) => {
     if (term.deepLink != "") {
-      term.executeCommandLine(term.deepLink, {
+      const parsed = term.parseCommandLine(term.deepLink);
+
+      if (parsed.cmd === "eval" && window.confirm(parsed.line) !== true) {
+        return;
+      }
+
+      term.executeCommandLine(parsed.line, {
         addToHistory: false,
         promptAfter: false,
         showLeadingNewline: false,

--- a/tests/terminal-ext.test.js
+++ b/tests/terminal-ext.test.js
@@ -145,6 +145,44 @@ describe("terminal-ext", () => {
     );
   });
 
+  it("requires exact confirmation before dispatching an eval deep link", () => {
+    const confirm = vi
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true);
+    const { extend } = loadTerminalExt({ confirm });
+    env.window.location.hash = "#eval-alert(1)";
+    const term = createTerm();
+
+    extend(term);
+    term.executeCommandLine = vi.fn(() => Promise.resolve());
+
+    term.runDeepLink();
+    term.runDeepLink({ replay: true });
+    term.runDeepLink();
+    term.runDeepLink({ replay: true });
+
+    expect(confirm).toHaveBeenNthCalledWith(1, "eval alert(1)");
+    expect(confirm).toHaveBeenNthCalledWith(2, "eval alert(1)");
+    expect(confirm).toHaveBeenNthCalledWith(3, "eval alert(1)");
+    expect(confirm).toHaveBeenNthCalledWith(4, "eval alert(1)");
+    expect(term.executeCommandLine).toHaveBeenCalledTimes(2);
+    expect(term.executeCommandLine).toHaveBeenNthCalledWith(1, "eval alert(1)", {
+      addToHistory: false,
+      promptAfter: false,
+      showLeadingNewline: false,
+      trackAnalytics: true,
+    });
+    expect(term.executeCommandLine).toHaveBeenNthCalledWith(2, "eval alert(1)", {
+      addToHistory: false,
+      promptAfter: false,
+      showLeadingNewline: false,
+      trackAnalytics: false,
+    });
+  });
+
   it.each([
     ["#jobs", "jobs"],
     ["#whois-root", "whois root"],


### PR DESCRIPTION
## Summary

- parse deep-link commands before dispatch and identify commands that resolve to `eval`
- require an explicit affirmative confirmation displaying the exact parsed command before dispatching an eval deep link
- prevent denied or unconfirmed eval links from dispatching, including resize replays
- add one focused regression test covering denial, an unconfirmed result, approval, exact confirmation text, and replay behavior

## Scope

The repair changes only:

- `js/terminal-ext.js`
- `tests/terminal-ext.test.js`

It does not change the deep-link parser structure, bootstrap preload path, command configuration, generated output, or introduce allowlist infrastructure.

## Validation

- `npm test` — passed (7 test files, 121 tests)
- `npm run build` — passed
- clean-checkout `npm test` — passed
- clean-checkout `npm run build` — passed
- adversarial review — completed with no actionable defect found

## Approvals and policy

All recorded policy decisions are `allow`, and the work packet has no open approvals or unresolved risks blocking delivery.

## ASD workflow

- Task: `task_0fdea2d9b09e47729861c25469f42a96`
- Workflow: `workflow_run_1d31313194df4511a302a00e73b236e9`
- Lane: `enterprise_bug_fix_council_v1`
- Work packet node: `prepare_outcome_delivery`

<!-- asd-delivery-assignment:ZGVsaXZlcnlfYXNzaWdubWVudF8xMTQ4NTA5YzE1NDg3ZDdjODRjYzBiYjM4ODlkNzk3Mg -->